### PR TITLE
Fix/mobile menu issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ If you want to translate this theme to your language, Please visit:- https://tra
 /**********************************************************/
 
 == CHANGE LOG ==
+= TBD =
+* Fix - Mobile menu issue when full width menu style is disabled.
+
 = Version 1.3.8 -2021-05-07 =
 * Fix - Inner wrap CSS clearfix issue. 
 * Tweak - Update screenshot image source link.

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ If you want to translate this theme to your language, Please visit:- https://tra
 
 == CHANGE LOG ==
 = TBD =
-* Fix - Mobile menu issue when full width menu style is disabled.
+* Fix - Mobile menu issue while full-width menu style disabled.
 
 = Version 1.3.8 -2021-05-07 =
 * Fix - Inner wrap CSS clearfix issue. 

--- a/style.css
+++ b/style.css
@@ -1906,12 +1906,11 @@ div#wp-custom-header:hover .wp-custom-header-video-button {
 	}
 
 	.main-small-navigation ul {
-    	position: absolute;
-    	max-height: 80vh;
-    	top: 100%;
-    	width: 200px;
-    	right: 60px;
-		margin-left: -134px;
+		position: absolute;
+		max-height: 80vh;
+		top: 100%;
+		width: 200px;
+		right: 60px;
 	}
 
 	.full-width-menu .main-small-navigation ul.menunav-menu,

--- a/style.css
+++ b/style.css
@@ -1896,7 +1896,7 @@ div#wp-custom-header:hover .wp-custom-header-video-button {
 	}
 
 	.main-small-navigation ul ul {
-		margin-left: 0;
+		margin-left: 60px;
 		position: relative;
 	}
 
@@ -1906,12 +1906,12 @@ div#wp-custom-header:hover .wp-custom-header-video-button {
 	}
 
 	.main-small-navigation ul {
-		overflow: auto;
     	position: absolute;
     	max-height: 80vh;
     	top: 100%;
-    	width: 100%;
-    	left: 0;
+    	width: 200px;
+    	right: 60px;
+		margin-left: -134px;
 	}
 
 	.full-width-menu .main-small-navigation ul.menunav-menu,


### PR DESCRIPTION
### Changes proposed in this Pull Request
- Fixed mobile menu issue when full width menu style is disabled.

### Type of change
- [ ] Code Refactor
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test the changes in this Pull Request:
1. Go to Responsive Menu Style from customizer,
2. Uncheck Switch to full width menu style, and
3. Check the responsive mobile menu.

### Checklist:
- [x] My code follows WordPress' coding standards
- [x] I've checked to ensure there are no other open Pull Requests for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have made perform a test that proves my fix is effective or that my feature works
### Did you test this issue fix on all browsers?
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] opera
### Changelog entry
 * Fix - Mobile menu issue when full width menu style is disabled.